### PR TITLE
Makes the pre-step more generic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,7 @@ To `rind` enable a container a  ``app.rind`` label needs to be added. Do do this
 
 Rind also has the ability to run pre-steps when executing inside the container. For example activating a Python virtualenv.
 
-In fact this is the *only* support pre-step currently. Ideas of others are welcome.
-
-To enable the virtualenv automatically prior to executing you need to add a value to your label.
+To enable a pre-step you need to add it as a value to your label.
 
 .. code-block:: yaml
 
@@ -36,10 +34,10 @@ To enable the virtualenv automatically prior to executing you need to add a valu
         a_service:
             image: an_image
             labels:
-                app.rind: "python"
+                app.rind: "source /venv/bin/activate"
 
 
-Currently this assumes you virtualenv is at ``/venv`` within your docker container.
+This assumes you virtualenv is at ``/venv`` within your docker container. It will be combined with the actual command passed in. e.g.: ``rind /bin/sh``  would be run in your container as ``source /venv/bin/activate && /bin/sh``
 
 
 Running

--- a/rind/__version__.py
+++ b/rind/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 1, 0)
+VERSION = (0, 2, 0)
 __version__ = '.'.join(map(str, VERSION))

--- a/rind/main.py
+++ b/rind/main.py
@@ -4,4 +4,7 @@ from . import service
 def main(client, params):
     container = service.get_container(client)
     print(f"RIND: {container.name} is the selected container")
-    service.execute(client.api, container, params)
+    prefix = container.labels.get('app.rind', None)
+    if prefix:
+        print(f"RIND: Using the exec prefix '{prefix}'")
+    service.execute(client.api, container, params, prefix)

--- a/rind/service.py
+++ b/rind/service.py
@@ -4,12 +4,6 @@ from dockerpty.pty import ExecOperation, PseudoTerminal
 
 from . import exceptions
 
-MODE_PREFIXES = {'python': 'source /venv/bin/activate && '}
-
-
-def get_mode(label):
-    return MODE_PREFIXES.get(label, '')
-
 
 @lru_cache(maxsize=1)
 def get_container(client):
@@ -21,15 +15,16 @@ def get_container(client):
     return containers[0]
 
 
-def execute(api, container, params):
+def execute(api, container, params, prefix):
     if not params:
         params = ['/bin/sh']
 
-    prefix = get_mode(container.labels.get('app.rind', ''))
+    if prefix:
+        params = [prefix, '&&'] + params
     cmd = [
         '/bin/sh',
         '-c',
-        prefix + " ".join(params),
+        " ".join(params),
     ]
     exec_id = api.exec_create(
         container=container.id, cmd=cmd, tty=True, stdin=True)


### PR DESCRIPTION
Using language or framework specific labels for the prefix/pre-step is somewhat retrictive and means that a new release of `rind` is neessary for each one added. Not ideal. As such the labels value has now been changed to *be* the pre-step.

e.g.:

`app.rind: python` needs to be changed to `app.rind: source /venv/bin/activate`.

This is combined (if present) to the actual passed in command with an `&&`